### PR TITLE
MAV plural typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ cause application bugs. The precise definitions of these anomalies are given in 
 
 | DBMS          | So-called isolation level    | Actual isolation level | G0 | G1a | G1b | G1c | OTV | PMP | P4 | G-single | G2-item | G2   |
 |:--------------|:-----------------------------|:-----------------------|:--:|:---:|:---:|:---:|:---:|:---:|:--:|:--------:|:-------:|:----:|
-| PostgreSQL    | "read committed" ★           | monotonic atomic views | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
+| PostgreSQL    | "read committed" ★           | monotonic atomic view | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
 |               | "repeatable read"            | snapshot isolation     | ✓  | ✓   | ✓   | ✓   | ✓   | ✓   | ✓  | ✓        | —       | —    |
 |               | "serializable"               | serializable           | ✓  | ✓   | ✓   | ✓   | ✓   | ✓   | ✓  | ✓        | ✓       | ✓    |
 |               |                              |                        |    |     |     |     |     |     |    |          |         |      |
 | MySQL/InnoDB  | "read uncommitted"           | read uncommitted       | ✓  | —   | —   | —   | —   | —   | —  | —        | —       | —    |
-|               | "read committed"             | monotonic atomic views | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
-|               | "repeatable read" ★          | monotonic atomic views | ✓  | ✓   | ✓   | ✓   | ✓   | R/O | —  | R/O      | —       | —    |
+|               | "read committed"             | monotonic atomic view | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
+|               | "repeatable read" ★          | monotonic atomic view | ✓  | ✓   | ✓   | ✓   | ✓   | R/O | —  | R/O      | —       | —    |
 |               | "serializable"               | serializable           | ✓  | ✓   | ✓   | ✓   | ✓   | ✓   | ✓  | ✓        | ✓       | ✓    |
 |               |                              |                        |    |     |     |     |     |     |    |          |         |      |
-| Oracle DB     | "read committed" ★           | monotonic atomic views | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
+| Oracle DB     | "read committed" ★           | monotonic atomic view | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
 |               | "serializable"               | snapshot isolation     | ✓  | ✓   | ✓   | ✓   | ✓   | ✓   | ✓  | ✓        | —       | some |
 |               |                              |                        |    |     |     |     |     |     |    |          |         |      |
 | MS SQL Server | "read uncommitted"           | read uncommitted       | ✓  | —   | —   | —   | —   | —   | —  | —        | —       | —    |
-|               | "read committed" (locking) ★ | monotonic atomic views | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
-|               | "read committed" (snapshot)  | monotonic atomic views | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
+|               | "read committed" (locking) ★ | monotonic atomic view | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
+|               | "read committed" (snapshot)  | monotonic atomic view | ✓  | ✓   | ✓   | ✓   | ✓   | —   | —  | —        | —       | —    |
 |               | "repeatable read"            | repeatable read        | ✓  | ✓   | ✓   | ✓   | ✓   | —   | ✓  | some     | ✓       | —    |
 |               | "snapshot"                   | snapshot isolation     | ✓  | ✓   | ✓   | ✓   | ✓   | ✓   | ✓  | ✓        | —       | —    |
 |               | "serializable"               | serializable           | ✓  | ✓   | ✓   | ✓   | ✓   | ✓   | ✓  | ✓        | ✓       | ✓    |


### PR DESCRIPTION
I think view in MAV should be singular, from Bailis et al

> ....Accordingly, here, we consider the isolation
> effects of atomicity, which we call Monotonic Atomic View
> (MAV) isolation...